### PR TITLE
Fix CI failure by removing default failing test and fixing typo

### DIFF
--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -7,6 +7,7 @@
 //
 
 @import XCTest;
+@import RBSOdometer;
 
 @interface Tests : XCTestCase
 
@@ -17,19 +18,17 @@
 - (void)setUp
 {
     [super setUp];
-    // Put setup code here. This method is called before the invocation of each test method in the class.
 }
 
 - (void)tearDown
 {
-    // Put teardown code here. This method is called after the invocation of each test method in the class.
     [super tearDown];
 }
 
-- (void)testExample
+- (void)testInitialization
 {
-    XCTFail(@"No implementation for \"%s\"", __PRETTY_FUNCTION__);
+    RBSOdometerView *view = [[RBSOdometerView alloc] initWithFrame:CGRectMake(0, 0, 100, 30)];
+    XCTAssertNotNil(view);
 }
 
 @end
-

--- a/RBSOdometer/Classes/RBSOdometerView.m
+++ b/RBSOdometer/Classes/RBSOdometerView.m
@@ -338,15 +338,15 @@ static NSString *const kAnimationKey = @"RBSOdometerAnimationKey";
     CGSize superSize = [super intrinsicContentSize];
     
     CGFloat height = 0;
-    CGFloat widht = 0;
+    CGFloat width = 0;
     for(NSUInteger i = 0; i < [_value length]; ++i){
         NSString *singString = [_value substringWithRange:NSMakeRange(i, 1)];
         CGSize stringSize = [self sizeWithText:singString];
         height = MAX(height, stringSize.height);
-        widht = widht + stringSize.width;
+        width = width + stringSize.width;
     }
     
-    superSize.width = widht;
+    superSize.width = width;
     superSize.height = height;
     return superSize;
 }


### PR DESCRIPTION
The CI was failing because the default `Example/Tests/Tests.m` contained `XCTFail`. This commit replaces the failing test with a basic initialization test. Additionally, it fixes a variable name typo (`widht` -> `width`) in `RBSOdometerView.m`.

---
*PR created automatically by Jules for task [14626730695865553638](https://jules.google.com/task/14626730695865553638) started by @RbBtSn0w*